### PR TITLE
Client Update

### DIFF
--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -15,6 +15,7 @@ try {
 catch (e) {
     /* empty */
 }
+
 /**
  * Type Definitions for config
  */
@@ -125,8 +126,8 @@ export default class ExtendedClient extends Client {
 
                 this.events.set(event.default.name, event.default);
 
-                if (event.default.once) { this.once(event.default.name, (...args) => event.default.execute(this, ...args)); }
-                else { this.on(event.default.name, (...args) => event.default.execute(this, ...args)); }
+                if (event.default.once) { this.once(event.default.name, (...args) => event.default.execute(...args)); }
+                else { this.on(event.default.name, (...args) => event.default.execute(...args)); }
             }),
         );
     }
@@ -215,4 +216,38 @@ function fileToCollection<Type extends Command | Interaction>(dirPath:string):Co
  */
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
     return error instanceof Error;
+}
+
+declare module 'discord.js' {
+    interface BaseInteraction {
+        client: ExtendedClient
+    }
+
+    interface Component {
+        client: ExtendedClient
+    }
+
+    interface Message {
+        client: ExtendedClient
+    }
+
+    interface BaseChannel {
+        client: ExtendedClient
+    }
+
+    interface Role {
+		client: ExtendedClient
+	}
+
+    interface Guild {
+		client: ExtendedClient
+	}
+
+	interface User {
+		client: ExtendedClient
+	}
+
+	interface GuildMember {
+		client: ExtendedClient
+	}
 }

--- a/src/commands/example/autocomplete.ts
+++ b/src/commands/example/autocomplete.ts
@@ -20,7 +20,7 @@ const command: ChatInputCommand = {
             .setRequired(true)
             .setAutocomplete(true)),
     global: true,
-    async execute(_client, interaction) {
+    async execute(interaction) {
         interaction.reply({
             content: i18n(interaction.locale, 'autocomplete-reply', { fruit: interaction.options.getString(fallback('autocomplete-option1-name'), true) }),
             ephemeral:true,

--- a/src/commands/example/modal.ts
+++ b/src/commands/example/modal.ts
@@ -12,7 +12,7 @@ const command: ChatInputCommand = {
         .setDMPermission(true)
         .setDefaultMemberPermissions(PermissionsBitField.Flags.SendMessages),
     global: true,
-    async execute(_client, interaction) {
+    async execute(interaction) {
         interaction.showModal(new ModalBuilder()
             .setCustomId('model')
             .setTitle(i18n(interaction.locale, 'modal-title'))

--- a/src/commands/example/ping.ts
+++ b/src/commands/example/ping.ts
@@ -13,7 +13,7 @@ const command: ChatInputCommand = {
         .setDMPermission(true)
         .setDefaultMemberPermissions(PermissionsBitField.Flags.SendMessages),
     global: true,
-    async execute(_client, interaction) {
+    async execute(interaction) {
         interaction.reply({ content: ` ${i18n(interaction.locale, 'ping-reply')} 🏓`, components: [getPingButton(interaction.locale)], ephemeral: true });
     },
 };

--- a/src/commands/example/select-menu.ts
+++ b/src/commands/example/select-menu.ts
@@ -22,7 +22,7 @@ const command: ChatInputCommand = {
                 .setDescription(fallback('select-menu-string-description'))
                 .setDescriptionLocalizations(localization('select-menu-string-description')))),
     global: true,
-    async execute(_client, interaction) {
+    async execute(interaction) {
         let row:ActionRowBuilder<MessageActionRowComponentBuilder>;
         switch (interaction.options.getSubcommand(true)) {
         case fallback('select-menu-string-name'):

--- a/src/context_menus/example/countCharacters.ts
+++ b/src/context_menus/example/countCharacters.ts
@@ -12,7 +12,7 @@ const contextMenu: MessageContextMenu = {
         .setType(ApplicationCommandType.Message) // Specify the context menu type
         .setDMPermission(false),
     global: false,
-    async execute(_client, interaction) {
+    async execute(interaction) {
         const message = interaction.targetMessage,
             length = message.content.length;
         await interaction.reply(

--- a/src/context_menus/example/displayAvatar.ts
+++ b/src/context_menus/example/displayAvatar.ts
@@ -12,13 +12,13 @@ const contextMenu: UserContextMenu = {
         .setType(ApplicationCommandType.User) // Specify the context menu type
         .setDMPermission(false),
     global: true,
-    async execute(client, interaction) {
+    async execute(interaction) {
         if (!interaction.inGuild()) return;
         const member = interaction.targetMember as GuildMember,
             embed = new EmbedBuilder()
                 .setTitle(i18n(interaction.guildLocale, 'avatar-embed', { 'username': member.displayName }))
                 .setImage(member.displayAvatarURL({ size:4096 }))
-                .setColor(client.config.colors.embed)
+                .setColor(interaction.client.config.colors.embed)
                 .setFooter({ text:`ID: ${member.id}` });
         interaction.reply({ embeds:[embed] });
     },

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,10 +1,11 @@
 import { Events } from 'discord.js';
+import ExtendedClient from '../classes/Client';
 import { Event } from '../interfaces';
 
 const event: Event = {
     name: Events.ClientReady,
     once: true,
-    execute: async (client) => {
+    execute: async (client:ExtendedClient) => {
         // Skip if no-deployment flag is set, else deploys commands
         if (!process.argv.includes('--no-deployment')) await client.deploy();
         console.log(`\nReady! Logged in as ${client.user?.tag} (${client.user?.id})\n`);

--- a/src/interactions/buttons/example/ping.ts
+++ b/src/interactions/buttons/example/ping.ts
@@ -6,7 +6,7 @@ import { Button } from '../../../interfaces';
 
 const button: Button = {
     name: 'ping',
-    async execute(_client, interaction) {
+    async execute(interaction) {
         interaction.reply({ content: `${i18n(interaction.locale, 'ping-button')} 🏓`, components: [getPingButton(interaction.locale)], ephemeral: true });
     },
 };

--- a/src/interactions/modals/example/model.ts
+++ b/src/interactions/modals/example/model.ts
@@ -4,11 +4,11 @@ import { ModalSubmit } from '../../../interfaces';
 
 const modal: ModalSubmit = {
     name: 'model',
-    async execute(client, interaction) {
+    async execute(interaction) {
         interaction.reply({
             embeds:[new EmbedBuilder()
                 .setTitle(i18n(interaction.locale, 'modal-embed-title'))
-                .setColor(client.config.colors.embed)
+                .setColor(interaction.client.config.colors.embed)
                 .setFields(
                     {
                         name: i18n(interaction.locale, 'modal-embed-short'),

--- a/src/interactions/select_menus/example/string.ts
+++ b/src/interactions/select_menus/example/string.ts
@@ -3,7 +3,7 @@ import { StringSelectMenu } from '../../../interfaces';
 
 const menu: StringSelectMenu = {
     name: 'string',
-    async execute(_client, interaction) {
+    async execute(interaction) {
         interaction.update({ content: i18n(interaction.locale, 'select-menu-string-reply'), components: [] });
     },
 };

--- a/src/interfaces/Command.ts
+++ b/src/interfaces/Command.ts
@@ -1,27 +1,26 @@
-import ExtendedClient from '../classes/Client';
 import { AutocompleteInteraction, ChatInputCommandInteraction, CommandInteraction, ContextMenuCommandBuilder, ContextMenuCommandInteraction, MessageContextMenuCommandInteraction, SlashCommandBuilder, SlashCommandSubcommandsOnlyBuilder, UserContextMenuCommandInteraction } from 'discord.js';
 
 export interface Command {
     options: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'> | ContextMenuCommandBuilder,
     global: boolean,
-    execute(client: ExtendedClient, interaction: CommandInteraction): Promise<void>
+    execute(interaction: CommandInteraction): Promise<void>
 }
 
 export interface ChatInputCommand extends Command {
     options: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>
-    execute(client: ExtendedClient, interaction: ChatInputCommandInteraction): Promise<void>,
+    execute(interaction: ChatInputCommandInteraction): Promise<void>,
     autocomplete?(interaction: AutocompleteInteraction): Promise<void>
 }
 
 export interface ContextMenu extends Command {
     options: ContextMenuCommandBuilder
-    execute(client: ExtendedClient, interaction: ContextMenuCommandInteraction): Promise<void>
+    execute(interaction: ContextMenuCommandInteraction): Promise<void>
 }
 
 export interface UserContextMenu extends ContextMenu {
-    execute(client: ExtendedClient, interaction: UserContextMenuCommandInteraction): Promise<void>
+    execute(interaction: UserContextMenuCommandInteraction): Promise<void>
 }
 
 export interface MessageContextMenu extends ContextMenu {
-    execute(client: ExtendedClient, interaction: MessageContextMenuCommandInteraction): Promise<void>
+    execute(interaction: MessageContextMenuCommandInteraction): Promise<void>
 }

--- a/src/interfaces/Event.ts
+++ b/src/interfaces/Event.ts
@@ -1,9 +1,8 @@
-import ExtendedClient from '../classes/Client';
 import { ClientEvents as DiscordClientEvents } from 'discord.js';
 
 export interface Event {
     name: keyof DiscordClientEvents;
     once?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    execute(client: ExtendedClient, ...args: any[]): void;
+    execute(...args: any[]): void;
 }

--- a/src/interfaces/Interaction.ts
+++ b/src/interfaces/Interaction.ts
@@ -1,39 +1,38 @@
 import { AnySelectMenuInteraction, ButtonInteraction, ChannelSelectMenuInteraction, Interaction as dInteraction, MentionableSelectMenuInteraction, ModalSubmitInteraction, RoleSelectMenuInteraction, StringSelectMenuInteraction, UserSelectMenuInteraction } from 'discord.js';
-import ExtendedClient from '../classes/Client';
 
 export interface Interaction {
     name: string;
-    execute(client: ExtendedClient, interaction: dInteraction): Promise<void>;
+    execute(interaction: dInteraction): Promise<void>;
 }
 
 export interface Button extends Interaction {
-    execute(client: ExtendedClient, interaction: ButtonInteraction): Promise<void>
+    execute(interaction: ButtonInteraction): Promise<void>
 }
 
 export interface ModalSubmit extends Interaction {
-    execute(client: ExtendedClient, interaction: ModalSubmitInteraction): Promise<void>
+    execute(interaction: ModalSubmitInteraction): Promise<void>
 }
 
 export interface AnySelectMenu extends Interaction {
-    execute(client: ExtendedClient, interaction: AnySelectMenuInteraction): Promise<void>
+    execute(interaction: AnySelectMenuInteraction): Promise<void>
 }
 
 export interface StringSelectMenu extends AnySelectMenu {
-    execute(client: ExtendedClient, interaction: StringSelectMenuInteraction): Promise<void>
+    execute(interaction: StringSelectMenuInteraction): Promise<void>
 }
 
 export interface MentionableSelectMenu extends AnySelectMenu {
-    execute(client: ExtendedClient, interaction: MentionableSelectMenuInteraction): Promise<void>
+    execute(interaction: MentionableSelectMenuInteraction): Promise<void>
 }
 
 export interface ChannelSelectMenu extends AnySelectMenu {
-    execute(client: ExtendedClient, interaction: ChannelSelectMenuInteraction): Promise<void>
+    execute(interaction: ChannelSelectMenuInteraction): Promise<void>
 }
 
 export interface RoleSelectMenu extends AnySelectMenu {
-    execute(client: ExtendedClient, interaction: RoleSelectMenuInteraction): Promise<void>
+    execute(interaction: RoleSelectMenuInteraction): Promise<void>
 }
 
 export interface UserSelectMenu extends AnySelectMenu {
-    execute(client: ExtendedClient, interaction: UserSelectMenuInteraction): Promise<void>
+    execute(interaction: UserSelectMenuInteraction): Promise<void>
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "sourceMap": true,
-        "strict": true,
+        "strict": false,
         "strictPropertyInitialization": false,
     },
     "include": [


### PR DESCRIPTION
Using module augmentation I was able to integrate the `ExtendedClient` into discord.js. This means that `ExtendedClient` no longer needs to be passed as a argument in functions.

```ts
declare module 'discord.js' {
    interface BaseInteraction { client: ExtendedClient }
    interface Component { client: ExtendedClient }
    interface Message { client: ExtendedClient }
    interface BaseChannel { client: ExtendedClient }
    interface Role { client: ExtendedClient }
    interface Guild { client: ExtendedClient }
    interface User { client: ExtendedClient }
    interface GuildMember { client: ExtendedClient }
}
```
### Note
To accomplish this `compilerOptions.strict` in `tsconfig.json` need to be set to `false`
```json
{
    "compilerOptions": {
        "strict": false,
    }
}